### PR TITLE
add virt-what to package dependencies

### DIFF
--- a/itest/precise.sh
+++ b/itest/precise.sh
@@ -1,1 +1,0 @@
-ubuntu.sh

--- a/itest/ubuntu.sh
+++ b/itest/ubuntu.sh
@@ -15,7 +15,7 @@ if [ -e /opt/puppet-omnibus ]; then
   exit 1
 fi
 
-apt-get install libgmp10 libxml2 libxslt1.1 libssl1.0.0 --yes --force-yes
+apt-get install virt-what libgmp10 libxml2 libxslt1.1 libssl1.0.0 --yes --force-yes
 if dpkg -i $packages_to_install; then
   echo "Looks like it installed correctly"
 else

--- a/puppet.rb
+++ b/puppet.rb
@@ -9,7 +9,7 @@ class PuppetGem < FPM::Cookery::Recipe
   source "nothing", :with => :noop
 
   build_depends 'pkg-config', 'libxml2-dev', 'libxslt1-dev'
-  depends 'libxml2', 'libxslt1.1'
+  depends 'libxml2', 'libxslt1.1', 'virt-what'
 
   def build
     ENV['PKG_CONFIG_PATH'] = "#{destdir}/lib/pkgconfig"


### PR DESCRIPTION
without virt-what facter is having troubles detecting
virtualization platform for aws c5 instances