### PR TITLE
Update default build versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PUPPET_GIT   := $(or ${upstream_puppet_git},"git://github.com/Yelp/puppet.git")
-VERSION      := $(or ${puppet_version},"3.8.1")
-ITERATION    := $(or ${puppet_vendor_version},y3)
+VERSION      := $(or ${puppet_version},"4.5.3")
+ITERATION    := $(or ${puppet_vendor_version},y4)
 PACKAGE_NAME := "puppet-omnibus"
 BUILD_NUMBER := $(or ${upstream_build_number},0)
 


### PR DESCRIPTION
This updates the default version and patch version used in the `Makefile` to what we are actually using so that you don't have to override these with environment variables to get a more correct build.