### PR TITLE
Default number of unicorn workers to number of cores minus one

### DIFF
--- a/puppet/unicorn.conf
+++ b/puppet/unicorn.conf
@@ -1,6 +1,6 @@
 # NOTE: This file is maintained in the puppet-omnibus package, NOT by puppet
 workers = ENV['PUPPET_OMNIBUS_WORKERS'].to_i
-workers = 12 if workers == 0
+workers = (`nproc`.to_i - 1) if workers == 0
 worker_processes workers
 
 working_directory "/opt/puppet-omnibus/var/lib/puppetmaster/rack"


### PR DESCRIPTION
Spoiler: I have no idea if this is actually going to work; I can build and test the package on a single puppetmaster for testing, so this PR is mostly a "will this even work" sanity test. Since unicorn.conf appears to just be Ruby, theoretically, we can just shell out to get the number of cores.

