### PR TITLE
Use ruby 2.2.10 on trusty too

### DIFF
--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -19,15 +19,14 @@ RUN rm -f /bin/sh && \
     cp /etc/gemrc /root/.gemrc && \
     cp /etc/gemrc /package/.gemrc
 
-ADD vendor/ruby-build-20140524.tar.gz /tmp
-ADD vendor/ruby-2.1.2-patches.tar.gz /tmp
+ADD vendor/ruby-build-20190719.tar.gz /tmp
 
 RUN mkdir -p /opt/puppet-omnibus/embedded && \
     export MAKE_OPTS="-j3 -s" && \
     export RUBY_CFLAGS=-Os && \
     export RUBY_BUILD_CACHE_PATH=/tmp && \
     export RUBY_CONFIGURE_OPTS="--without-gdbm --without-dbm --disable-install-doc --without-tcl --without-tk" && \
-    cat /tmp/ruby-2.1.2-patches/* | /tmp/ruby-build-20140524/bin/ruby-build -p 2.1.2 /opt/puppet-omnibus/embedded
+    /tmp/ruby-build-20190719/bin/ruby-build -p 2.2.10 /opt/puppet-omnibus/embedded
 
 RUN /opt/puppet-omnibus/embedded/bin/gem install rubygems-update -v '<3' && \
     /opt/puppet-omnibus/embedded/bin/update_rubygems && \


### PR DESCRIPTION
This builds just fine on trusty (tested with `make itest_trusty`) and fixes the build there (mostly in case we need to fix other things about puppet on trusty in the future, I'm all too ready to remove trusty entirely otherwise). This is essentially the same change as in #12, but for trusty too.