### PR TITLE
Upgrade nginx

### DIFF
--- a/nginx.rb
+++ b/nginx.rb
@@ -2,11 +2,11 @@ class Nginx < FPM::Cookery::Recipe
   description 'a high performance web server and a reverse proxy server'
 
   name     'nginx'
-  version  '1.11.2'
-  revision 3
+  version  '1.13.12'
+  revision 1
   homepage 'http://nginx.org/'
   source   "http://nginx.org/download/nginx-#{version}.tar.gz"
-  sha1     '3d6b4a0ea0f5b09bf83537111a8c80a3f26f81ae'
+  sha1     'ad26921175b28acb8ae6c4eda59050df83279e6e'
 
   section 'System Environment/Daemons'
 


### PR DESCRIPTION
PEAUTO-660 we need >= 1.13.5 for the '$ssl_client_escaped_cert' variable
And NLB only support proxy protocol v2. According to: https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/
'To accept the PROXY protocol v2, NGINX Plus R16 and later or NGINX open source 1.13.11 and later'

I just went with the last/latest release in the 1.13 series.