### PR TITLE
grab versioned facter folder

### DIFF
--- a/JENKINS_BUILD.sh
+++ b/JENKINS_BUILD.sh
@@ -33,7 +33,7 @@ cd /package
 gem install json_pure -v 2.5.1
 gem install /package/vendor/puppet-$PUPPET_VERSION.gem
 FACTER_RB=$(/opt/puppet-omnibus/embedded/bin/gem which facter)
-cd ${FACTER_RB::-3}
+cd ${FACTER_RB::-3} # strip .rb from facter path to get the folder
 patch -p9 < /tmp/facter.patch
 cd /package
 bundle install --local --path /tmp

--- a/JENKINS_BUILD.sh
+++ b/JENKINS_BUILD.sh
@@ -32,7 +32,8 @@ mv pkg/puppet-$PUPPET_VERSION.gem /package/vendor/
 cd /package
 gem install json_pure -v 2.5.1
 gem install /package/vendor/puppet-$PUPPET_VERSION.gem
-cd /opt/puppet-omnibus/embedded/lib/ruby/gems/2.4.0/gems/facter-2.5.7/lib/facter
+FACTER_RB=$(/opt/puppet-omnibus/embedded/bin/gem which facter)
+cd ${FACTER_RB::-3}
 patch -p9 < /tmp/facter.patch
 cd /package
 bundle install --local --path /tmp


### PR DESCRIPTION
`cd /opt/puppet-omnibus/embedded/lib/ruby/gems/2.4.0/gems/facter-2.5.7/lib/facter`
is failing on bionic/xenial because they are on ruby 2.2.

Grabbed full path from facter version instead
```
$ /opt/puppet-omnibus/embedded/bin/gem which facter 
/opt/puppet-omnibus/embedded/lib/ruby/gems/2.2.0/gems/facter-2.5.7/lib/facter.rb
```